### PR TITLE
Foundry で Arbitrum デプロイ環境を構築する (vibe-kanban)

### DIFF
--- a/contract/.env.example
+++ b/contract/.env.example
@@ -1,5 +1,11 @@
 export API_KEY_ALCHEMY="YOUR_API_KEY_ALCHEMY"
 export API_KEY_ETHERSCAN="YOUR_API_KEY_ETHERSCAN"
 export API_KEY_INFURA="YOUR_API_KEY_INFURA"
+export API_KEY_ARBISCAN="YOUR_API_KEY_ARBISCAN" # Arbiscan API key for Arbitrum (One/Sepolia)
 export MNEMONIC="YOUR_MNEMONIC"
 export FOUNDRY_PROFILE="default"
+
+# Optional: RPC endpoints (used for local fork/testing)
+# If unset, foundry.toml has sane defaults for alias resolution.
+export ARBITRUM_RPC_URL="https://arbitrum-one-rpc.publicnode.com"           # Arbitrum One
+export ARBITRUM_SEPOLIA_RPC_URL="https://sepolia-rollup.arbitrum.io/rpc"    # Arbitrum Sepolia

--- a/contract/foundry.toml
+++ b/contract/foundry.toml
@@ -21,6 +21,8 @@
 
 [etherscan]
   mainnet = { key = "${API_KEY_ETHERSCAN}" }
+  arbitrum = { key = "${API_KEY_ARBISCAN}" }
+  arbitrum_sepolia = { key = "${API_KEY_ARBISCAN}" }
 
 [fmt]
   bracket_spacing = true
@@ -34,6 +36,7 @@
 
 [rpc_endpoints]
   arbitrum = "https://arbitrum-one-rpc.publicnode.com"
+  arbitrum_sepolia = "https://sepolia-rollup.arbitrum.io/rpc"
   avalanche = "https://avalanche-c-chain-rpc.publicnode.com"
   base = "https://mainnet.base.org"
   bnb_smart_chain = "https://bsc-dataseed.binance.org"

--- a/contract/package.json
+++ b/contract/package.json
@@ -33,6 +33,8 @@
     "prettier:write": "prettier --write \"**/*.{json,md,yml}\"",
     "test": "forge test",
     "test:coverage": "forge coverage",
-    "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage"
+    "test:coverage:report": "forge coverage --report lcov && genhtml lcov.info --branch-coverage --output-dir coverage",
+    "deploy:arb": "forge script script/Deploy.s.sol --rpc-url arbitrum --broadcast --verify --dry-run --slow",
+    "deploy:arb-sepolia": "forge script script/Deploy.s.sol --rpc-url arbitrum_sepolia --broadcast --verify --slow"
   }
 }


### PR DESCRIPTION
# Foundry で Arbitrum デプロイ環境を構築する

## 背景

- 本プロジェクトのスマートコントラクトは Foundry（Forge）ベースで開発している。
- 今後、Arbitrum One もしくは Arbitrum Sepolia へデプロイして動作確認・検証・継続開発を進めたい。
- チーム内で再現可能なデプロイ手順・環境変数・検証（verify）フローを標準化し、CI/CD ないし手動運用でも迷わない状態にすることが目的。

## 問題点

- `contract/foundry.toml` に Etherscan 設定はあるが、Arbitrum 用の API Key 設定が未整備。
- `contract/.env.example` に Arbitrum 関連の環境変数（例: `API_KEY_ARBISCAN`, 任意の RPC URL）が未記載。
- デプロイ実行時のアカウント指定ポリシーが曖昧（`MNEMONIC` 想定だが README に明記なし。`ETH_FROM`/`PRIVATE_KEY` 併用可否も不明）。
- Arbitrum One / Arbitrum Sepolia それぞれの RPC エンドポイント・検証先の整理不足（verify の動作確認未実施）。
- ローカル検証（Anvil フォーク）とテストネット（Arbitrum Sepolia）の段階的デプロイ手順がドキュメント化されていない。

## 提案

- 環境変数の標準化と `.env.example` の拡充
  - `API_KEY_ARBISCAN` を追記（Arbiscan 用）
  - 任意: `ARBITRUM_RPC_URL`, `ARBITRUM_SEPOLIA_RPC_URL` を追記
  - デプロイ鍵は基本 `MNEMONIC` を採用（現行 `script/Base.s.sol` 構成と整合）。必要に応じて `ETH_FROM` の説明を README に追記
- `foundry.toml` の更新
  - `[etherscan]` セクションに `arbitrum`（および `arbitrum_sepolia`）のキー設定を追加
  - `[rpc_endpoints]` に `arbitrum_sepolia` を追加（あるいは環境変数で上書きできる旨を README に明記）
- スクリプト/コマンドの整備
  - `package.json` に `deploy:arb`, `deploy:arb-sepolia` を追加
  - 例: `forge script script/Deploy.s.sol --rpc-url arbitrum --broadcast --verify --slow`
  - 例: `forge script script/Deploy.s.sol --rpc-url arbitrum_sepolia --broadcast --verify --slow`
- ドキュメント整備
  - `contract/README.md` に「Arbitrum へデプロイ」章を追加し、前提・環境変数・手順・トラブルシュート・費用の目安を記載
  - CI での自動デプロイは当面対象外（手動のみ）。将来的に workflow 化する前提で Issue を分割

## 期待される変更

- `contract/.env.example`
  - `API_KEY_ARBISCAN` を追記
  - 任意: `ARBITRUM_RPC_URL`, `ARBITRUM_SEPOLIA_RPC_URL` を追記とコメント
- `contract/foundry.toml`
  - `[etherscan]` に `arbitrum = { key = "${API_KEY_ARBISCAN}" }` と `arbitrum_sepolia = { key = "${API_KEY_ARBISCAN}" }` を追加
  - `[rpc_endpoints]` に `arbitrum_sepolia = "https://sepolia-rollup.arbitrum.io/rpc"` を追加（必要なら環境変数差し替え）
- `contract/package.json`
  - `deploy:arb`, `deploy:arb-sepolia` の npm/bun スクリプトを追加
- `contract/README.md`
  - 「Arbitrum デプロイ手順」章の追加（前提・コマンド例・verify・よくあるエラー）

## テストの内容（受け入れ基準）

- ローカルフォーク検証
  - `anvil --fork-url $ARBITRUM_RPC_URL` を起動し、`forge script script/Deploy.s.sol --rpc-url http://localhost:8545 --broadcast` が成功すること
  - デプロイ先アドレス・ログを確認できること
- テストネット検証（Arbitrum Sepolia）
  - 少額ファンドした `MNEMONIC` を用い、`deploy:arb-sepolia` が成功すること
  - `--verify` により Arbiscan（Sepolia）で自動検証が通ること（Contract Code Verified）
- メインネット乾式実行
  - `forge script ... --rpc-url arbitrum --broadcast --dry-run` でシミュレーション成功
  - 実ブロードキャストは別 Issue/手順で管理（本 Issue では dry-run の成功をもって完了とする）
- ドキュメント確認
  - `.env.example` と `README` に従って環境構築→デプロイまでを新規メンバーが再現できること

---

参考コマンド例（採用予定）

```bash
# Anvil フォーク（任意）
anvil --fork-url "$ARBITRUM_RPC_URL"

# 環境変数
export MNEMONIC="..."           # Base.s.sol 前提
export API_KEY_ARBISCAN="..."   # Arbiscan API Key

# Arbitrum One（ドライラン）
forge script script/Deploy.s.sol \
  --rpc-url arbitrum \
  --broadcast --verify --dry-run --slow

# Arbitrum Sepolia（本番テスト）
forge script script/Deploy.s.sol \
  --rpc-url arbitrum_sepolia \
  --broadcast --verify --slow
```

