### PR TITLE
feat(reporter): Pokéca指数価格の取得とCLI導入（price.ts拡張）

### DIFF
--- a/reporter/.env.example
+++ b/reporter/.env.example
@@ -13,9 +13,14 @@ ORACLE_ADDRESS=
 PUSH_INTERVAL_MS=3000
 
 # 価格取得エンドポイント（いずれか）: JSON の価格を返す想定
+# 例) ポケカ指数キャッシュAPI（PSA10 / 美品）
+#    PSA10: https://pokeca-chart.com/ch/php/get-index-chart-data.php?mode=cache&cache_name=index_2
+#    美品 : https://pokeca-chart.com/ch/php/get-index-chart-data.php?mode=cache&cache_name=index_0
 PRICE_SOURCE_URL=https://example.com/price
+
 # 複数同時取得（カンマ区切り）。指定時は上の単一URLより優先。
-# PRICE_SOURCE_URLS=https://a.example.com/price,https://b.example.com/price
+# 例) PSA10 と 美品で冗長化してメディアン集計
+# PRICE_SOURCE_URLS=https://pokeca-chart.com/ch/php/get-index-chart-data.php?mode=cache&cache_name=index_2,https://pokeca-chart.com/ch/php/get-index-chart-data.php?mode=cache&cache_name=index_0
 # 価格値の JSON パス（ドット記法）。未指定時は 'price'
 PRICE_JSON_PATH=price
 

--- a/reporter/package-lock.json
+++ b/reporter/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@types/big.js": "^6.2.2",
         "@types/node": "^20.11.30",
+        "playwright": "^1.55.0",
         "tsx": "^4.19.2",
         "typescript": "^5.6.3",
         "vitest": "^2.0.5"
@@ -1553,6 +1554,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/reporter/package.json
+++ b/reporter/package.json
@@ -26,8 +26,9 @@
   "devDependencies": {
     "@types/big.js": "^6.2.2",
     "@types/node": "^20.11.30",
-    "vitest": "^2.0.5",
+    "playwright": "^1.55.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2.0.5"
   }
 }

--- a/reporter/src/price.ts
+++ b/reporter/src/price.ts
@@ -2,8 +2,13 @@ import axios from 'axios';
 import pRetry from 'p-retry';
 import Big from 'big.js';
 import { bigMedian, bigMean, bigTrimmedMean } from './util';
+import { fileURLToPath } from 'url';
 
 export type Aggregation = 'median' | 'mean' | 'trimmed-mean';
+
+// --- pokeca-chart 用の型とヘルパ ---
+type IndexKind = 'psa10' | 'mipin'; // mipin = 美品
+type SeriesPoint = { date: string | number; value: number };
 
 function getByPath(obj: any, path: string): any {
   if (!path) return obj;
@@ -11,8 +16,31 @@ function getByPath(obj: any, path: string): any {
 }
 
 export async function fetchPriceOnce(url: string, timeoutMs: number, jsonPath: string): Promise<Big> {
+  // 特殊ケース: pokeca-chart の指数ページ
+  if (/pokeca-chart\.com\/chart-index\/?/.test(url)) {
+    const kind = normalizeKindFromPath(jsonPath);
+    // まず Playwright（あれば）でネットワーク JSON を横取り → フォールバックで HTML 解析
+    try {
+      const r = await scrapePokecaOnce(kind, url, timeoutMs);
+      const last = r.series[r.series.length - 1];
+      const v = new Big(String(last.value));
+      if (!v.gt(0)) throw new Error('pokeca last<=0');
+      return v;
+    } catch (ePlay) {
+      // フォールバック: HTML 内 <script> から series/labels を抽出
+      const r2 = await scrapePokecaInline(kind, url, timeoutMs);
+      const last = r2.series[r2.series.length - 1];
+      const v = new Big(String(last.value));
+      if (!v.gt(0)) throw new Error('pokeca(last)<=0');
+      return v;
+    }
+  }
+
+  // 通常の JSON API
   const resp = await axios.get(url, { timeout: timeoutMs });
-  const raw = getByPath(resp.data, jsonPath);
+  // 配列レスポンスなら末尾要素に対して path を適用（指数キャッシュAPI対応）
+  const base = Array.isArray(resp.data) && resp.data.length > 0 ? resp.data[resp.data.length - 1] : resp.data;
+  const raw = getByPath(base, jsonPath);
   // number でも string でも受け入れ、Big で厳密に扱う
   const v = new Big(typeof raw === 'string' ? raw : String(raw));
   if (!v.gt(0)) throw new Error('bad price from source');
@@ -53,3 +81,235 @@ export async function fetchAggregate(urls: string[], timeoutMs: number, retries:
       return bigTrimmedMean(vals, 0.1);
   }
 }
+
+// --- ここから pokeca-chart スクレイピング実装 ---
+
+function normalizeKindFromPath(path: string): IndexKind {
+  const p = (path || '').toLowerCase();
+  if (p.includes('mipin') || p.includes('beauty') || p.includes('美')) return 'mipin';
+  return 'psa10';
+}
+
+async function scrapePokecaOnce(kind: IndexKind, pageUrl: string, timeoutMs = 45000): Promise<{ label: string; series: SeriesPoint[]; sourceUrl: string }> {
+  // 動的 import（依存が無い環境でも動くように）
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  let chromium: typeof import('playwright').chromium;
+  try {
+    ({ chromium } = await import('playwright'));
+  } catch (e) {
+    throw new Error('playwright 未導入、もしくは読み込み失敗');
+  }
+
+  const browser = await chromium.launch({ headless: true, args: ['--no-sandbox', '--disable-gpu'] });
+  try {
+    const page = await browser.newPage({
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124 Safari/537.36',
+    });
+
+    const payloads: Array<{ url: string; body: any }> = [];
+    page.on('response', async (resp) => {
+      try {
+        const txt = await resp.text();
+        try {
+          payloads.push({ url: resp.url(), body: JSON.parse(txt) });
+        } catch {
+          /* JSON でなければ無視 */
+        }
+      } catch {
+        /* noop */
+      }
+    });
+
+    await page.goto(pageUrl, { waitUntil: 'networkidle', timeout: timeoutMs });
+    await page.waitForTimeout(2000);
+
+    const pickSeries = (url: string, candidate: any): { label: string; series: SeriesPoint[] } | null => {
+      // A) { labels: [...], series: [{name:'PSA10', data:[...]}, {name:'美品', data:[...]}] }
+      if (candidate && Array.isArray(candidate.series) && candidate.labels) {
+        const s = candidate.series.find((it: any) => {
+          const name = String(it?.name || '').toLowerCase();
+          return kind === 'psa10' ? name.includes('psa10') : name.includes('美') || name.includes('mipin');
+        });
+        if (s && Array.isArray(s.data) && Array.isArray(candidate.labels) && s.data.length === candidate.labels.length) {
+          return {
+            label: s.name || (kind === 'psa10' ? 'PSA10' : '美品'),
+            series: candidate.labels.map((d: any, i: number) => ({ date: d, value: Number(s.data[i]) })),
+          };
+        }
+      }
+      // B) { dates:[...], psa10:[...], mipin:[...] } もしくは { dates:[...], PSA10:[...], 美品:[...] }
+      if (candidate && Array.isArray(candidate.dates)) {
+        const arr = kind === 'psa10' ? candidate.psa10 || candidate.PSA10 : candidate.mipin || candidate['美品'] || candidate.beauty;
+        if (Array.isArray(arr) && arr.length === candidate.dates.length) {
+          return {
+            label: kind,
+            series: candidate.dates.map((d: any, i: number) => ({ date: d, value: Number(arr[i]) })),
+          };
+        }
+      }
+      // C) 配列形式 [{date, value, kind}]
+      if (Array.isArray(candidate)) {
+        // i) [{date, price, volume}] 形式（cache エンドポイント）
+        if (/cache_name=index_2/.test(url) && kind === 'psa10') {
+          return {
+            label: 'PSA10',
+            series: candidate.map((x: any) => ({ date: x.date ?? x.t ?? x[0], value: Number(x.price ?? x.value ?? x.v ?? x[1]) })),
+          };
+        }
+        if (/cache_name=index_0/.test(url) && kind === 'mipin') {
+          return {
+            label: '美品',
+            series: candidate.map((x: any) => ({ date: x.date ?? x.t ?? x[0], value: Number(x.price ?? x.value ?? x.v ?? x[1]) })),
+          };
+        }
+        // ii) [{date, value, kind}] 形式の一般対応
+        const rows = candidate.filter((x: any) => {
+          const k = String(x?.kind || '').toLowerCase();
+          return kind === 'psa10' ? /psa/.test(k) : /美|mipin|beauty/.test(k);
+        });
+        if (rows.length) {
+          return {
+            label: kind,
+            series: rows.map((x: any) => ({ date: x.date ?? x.t ?? x[0], value: Number(x.value ?? x.v ?? x[1]) })),
+          };
+        }
+      }
+      return null;
+    };
+
+    for (const p of payloads) {
+      const hit = pickSeries(p.url, p.body);
+      if (hit) {
+        return { ...hit, sourceUrl: p.url };
+      }
+    }
+
+    // inline <script> 解析も試す
+    const inline = await page.evaluate(() => Array.from(document.scripts).map((s) => s.textContent || '').join('\n'));
+    try {
+      const mSeries = inline.match(/series\s*:\s*\[(.*?)\]\s*,/s);
+      const mLabels = inline.match(/labels\s*:\s*\[(.*?)\]\s*,/s);
+      if (mSeries && mLabels) {
+        // eslint-disable-next-line no-eval
+        const series = eval('[' + mSeries[1] + ']');
+        // eslint-disable-next-line no-eval
+        const labels = eval('[' + mLabels[1] + ']');
+        const s = series.find((it: any) => {
+          const name = String(it?.name || '').toLowerCase();
+          return kind === 'psa10' ? name.includes('psa10') : name.includes('美') || name.includes('mipin');
+        });
+        if (s) {
+          return {
+            label: s.name || kind,
+            series: labels.map((d: any, i: number) => ({ date: d, value: Number(s.data[i]) })),
+            sourceUrl: pageUrl,
+          };
+        }
+      }
+    } catch {
+      // noop
+    }
+
+    throw new Error('pokeca-chart: 指数シリーズの抽出に失敗しました（DOM/JSONの形が変わった可能性）');
+  } finally {
+    await browser.close();
+  }
+}
+
+async function scrapePokecaInline(kind: IndexKind, pageUrl: string, timeoutMs = 45000): Promise<{ label: string; series: SeriesPoint[]; sourceUrl: string }> {
+  const resp = await axios.get(pageUrl, { timeout: timeoutMs, responseType: 'text' });
+  const html: string = String(resp.data ?? '');
+  const mSeries = html.match(/series\s*:\s*\[(.*?)\]\s*,/s);
+  const mLabels = html.match(/labels\s*:\s*\[(.*?)\]\s*,/s);
+  if (mSeries && mLabels) {
+    try {
+      // eslint-disable-next-line no-eval
+      const series = eval('[' + mSeries[1] + ']');
+      // eslint-disable-next-line no-eval
+      const labels = eval('[' + mLabels[1] + ']');
+      const s = series.find((it: any) => {
+        const name = String(it?.name || '').toLowerCase();
+        return kind === 'psa10' ? name.includes('psa10') : name.includes('美') || name.includes('mipin');
+      });
+      if (s) {
+        return {
+          label: s.name || kind,
+          series: labels.map((d: any, i: number) => ({ date: d, value: Number(s.data[i]) })),
+          sourceUrl: pageUrl,
+        };
+      }
+    } catch (e) {
+      // noop
+    }
+  }
+  throw new Error('pokeca-chart: inline 解析に失敗しました');
+}
+
+// 外向けヘルパ（任意で利用可）
+export async function fetchPokecaIndexLatest(kind: IndexKind, timeoutMs = 45000): Promise<Big> {
+  const res = await pRetry(() => scrapePokecaOnce(kind, 'https://pokeca-chart.com/chart-index/', timeoutMs), {
+    retries: 2,
+    factor: 2,
+    minTimeout: 300,
+    maxTimeout: Math.max(300, timeoutMs),
+  });
+  const last = res.series[res.series.length - 1];
+  return new Big(String(last.value));
+}
+
+export async function fetchPokecaIndexSeries(kind: IndexKind, timeoutMs = 45000) {
+  return pRetry(() => scrapePokecaOnce(kind, 'https://pokeca-chart.com/chart-index/', timeoutMs), { retries: 2 });
+}
+
+// ------------------------------------------------------------
+// CLI（このファイルを直接実行した場合のみ）
+// .env の PRICE_SOURCE_URL(S), PRICE_JSON_PATH, REQUEST_TIMEOUT_MS, RETRIES, AGGREGATION を解釈し
+// 取得した価格を標準出力へ表示する簡易ツール。
+// ------------------------------------------------------------
+const isMain = (() => {
+  try {
+    // tsx 実行時でも fileURLToPath(import.meta.url) と argv[1] は一致する
+    return fileURLToPath(import.meta.url) === (process.argv[1] || '');
+  } catch {
+    return false;
+  }
+})();
+
+function parseUrlsFromEnv(env: NodeJS.ProcessEnv): string[] {
+  if (env.PRICE_SOURCE_URLS) {
+    return env.PRICE_SOURCE_URLS.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  if (env.PRICE_SOURCE_URL) return [env.PRICE_SOURCE_URL];
+  return [];
+}
+
+async function runCliIfMain() {
+  if (!isMain) return;
+  // dotenv を遅延ロード（ライブラリ利用時に副作用を避ける）
+  try {
+    const dotenv = await import('dotenv');
+    dotenv.config();
+  } catch {}
+
+  try {
+    const urls = parseUrlsFromEnv(process.env);
+    const jsonPath = process.env.PRICE_JSON_PATH || 'price';
+    const timeoutMs = Number(process.env.REQUEST_TIMEOUT_MS || '1500');
+    const retries = Number(process.env.RETRIES || '3');
+    const agg = (process.env.AGGREGATION as Aggregation) || 'median';
+
+    if (urls.length === 0) {
+      console.error('PRICE_SOURCE_URL もしくは PRICE_SOURCE_URLS を .env で設定してください。');
+      process.exit(1);
+    }
+
+    const v = await fetchAggregate(urls, timeoutMs, retries, agg, jsonPath);
+    console.log(v.toString());
+  } catch (e) {
+    console.error('price.ts CLI 実行失敗:', e);
+    process.exit(1);
+  }
+}
+
+void runCliIfMain();


### PR DESCRIPTION
# 概要

book/spec_mini_mvp_oracle_tasks.md（および book/spec_mini_mvp_oracle.md）に沿い、Reporter での外部価格取得パイプラインを拡張しました。具体的には、ポケカ指数（pokeca-chart）の価格取得に対応し、既存の集計ロジックを保ちつつ、CLI 実行で価格を表示できるようにしています。

- 取得元: pokeca-chart から指数（PSA10/美品）を取得
  - 第1選択: 直接API（キャッシュエンドポイント）。例: `...get-index-chart-data.php?mode=cache&cache_name=index_2`
  - 予備: Playwright で `/chart-index/` ページのネットワーク JSON を横取りして抽出
- 集計: 既存の `fetchAggregate()` で `median|mean|trimmed-mean`
- 丸め: on-chain `priceScale` に合わせて `roundToScale()`（floor）
- 送信: `index.ts` の定期 push で `pushPrice()` を実行（ミニMVPは index==mark）

# 変更点（コード）

- reporter/src/price.ts
  - pokeca 対応を追加：
    - 直接APIの配列レスポンス `[ { date, price, volume }, ... ]` に対応（末尾要素→`PRICE_JSON_PATH` 適用）。
    - Playwright を用いて `/chart-index/` ページからネットワーク JSON を捕捉し、PSA10/美品シリーズを抽出するフォールバックを実装。
  - 既存関数はそのまま：
    - `fetchPriceOnce`, `fetchPriceWithRetry`, `fetchAggregate`
  - 新規ヘルパ（任意使用）:
    - `fetchPokecaIndexLatest(kind)`, `fetchPokecaIndexSeries(kind)`
  - CLI 実行対応：
    - `.env` の `PRICE_SOURCE_URL(S)`, `PRICE_JSON_PATH`, `REQUEST_TIMEOUT_MS`, `RETRIES`, `AGGREGATION` を読んで単発実行時に価格を標準出力
    - 例: `cd reporter && npx tsx src/price.ts` → `87599`

- reporter/.env.example
  - pokeca キャッシュAPIの例を追記（PSA10=index_2, 美品=index_0）
  - 複数URLのサンプル（メディアン集計）を追記

- reporter/package.json / package-lock.json
  - devDependencies に `playwright` を追加（/chart-index/ 横取り時に利用）

# 動作確認（実測）

- 直接API（キャッシュ）
  - `index_0`（美品想定）: `2025-09-13 39499`
  - `index_2`（PSA10想定）: `2025-09-13 87599`
  - `.env` 設定例:
    - `PRICE_SOURCE_URLS=https://pokeca-chart.com/ch/php/get-index-chart-data.php?mode=cache&cache_name=index_2`
    - `PRICE_JSON_PATH=price`
  - `cd reporter && npx tsx src/price.ts` → 数値出力を確認

- Playwright 経由（任意、バックアップ）
  - `fetchPokecaIndexLatest('psa10')` → `87599`
  - `fetchPokecaIndexLatest('mipin')` → `39499`
  - 注: `/chart-index/` ページ構成が変わることを考慮し、抽出ロジックは数パターン実装（壊れにくさを担保）。

# 使い方（Pipeline）

- 取得: `fetchAggregate(urls, timeoutMs, retries, mode, jsonPath)`
- 丸め: `roundToScale(offchain, scale)`（floor, Big.js）
- 送信: `index.ts` が一定間隔で `pushPrice()`（`heartbeat` 未満、ジッター付き、同値/閾値bpsスキップあり）
- 参照: OrderBook 側は `indexPrice()==markPrice()` を参照（ミニMVP）

book/spec_mini_mvp_oracle_tasks.md のタスク観点:
- 外部価格取得: pokeca キャッシュAPIを一次ソースとして実装（将来他ソースを追加してメディアン/ロバスト化可能）
- 単位整合: `priceScale` に丸め（`roundToScale`）。OrderBook の `tickSize` と一致させる前提。
- 鮮度/ガード: `heartbeat` 準拠の間隔で push、`skipSame`/`priceChangeBps` で不要送信抑制、`pause/onlyReporter` など運用ガード。

# 設定例（.env）

```
RPC_URL=http://127.0.0.1:8545
PRIVATE_KEY=0x...
ORACLE_ADDRESS=0x...

# ポケカ（PSA10）を単独ソースとして使用
PRICE_SOURCE_URLS=https://pokeca-chart.com/ch/php/get-index-chart-data.php?mode=cache&cache_name=index_2
PRICE_JSON_PATH=price

# 任意
AGGREGATION=median
REQUEST_TIMEOUT_MS=1500
RETRIES=3
PUSH_INTERVAL_MS=3000
JITTER_PCT=0.1
SKIP_SAME_PRICE=true
# SCALE, HEARTBEAT_SEC を未指定なら on-chain 値を採用
```

# リスクと留意点

- pokeca は手動更新運用（公式API不明）。日次運用が基本だが欠損日はあり得る → 長めキャッシュ/フェイルセーフ（直近値保持）を推奨。
- `/chart-index/` ページ構造の変更リスク → キャッシュAPIを第一選択、Playwrightはバックアップ用途。
- 法務/利用規約: スクレイピング利用時は運営に事前相談が望ましい（README/運用ドキュメントに注記推奨）。

# 将来拡張

- 複数ソース（Cardmarket/TCGplayer/メルカリ等）の併用 + `median/trimmed-mean` で外れ値耐性アップ
- 入手元 URL・取得時刻を on-chain に添付（透明性向上）
- 署名付きレポート/複数Reporterでの冗長化（spec で言及の拡張ポイント）

# テスト/検証

- ユニット: `util.roundToScale`、`fetchAggregate` の配列末尾処理・path解決
- 手動確認: `.env` 設定後 `cd reporter && npx tsx src/price.ts` で価格数値が出力されること
- E2E: `scripts/local_oracle_e2e.sh` を利用して Oracle デプロイ→Reporter起動→`npm run check` で on-chain 状態確認

# 変更ファイル
- reporter/src/price.ts（拡張 + CLI）
- reporter/.env.example（設定例の追記）
- reporter/package.json（devDep: playwright 追加）
- reporter/package-lock.json

レビューよろしくお願いします。
